### PR TITLE
feat: Keychain isolation

### DIFF
--- a/Feather/Backend/Observable/OptionsManager.swift
+++ b/Feather/Backend/Observable/OptionsManager.swift
@@ -102,6 +102,8 @@ struct Options: Codable, Equatable {
 	var changeLanguageFilesForCustomDisplayName: Bool
 	/// If tweaks should be injected into all app extensions (PlugIns and Extensions)
 	var injectIntoExtensions: Bool
+	/// If app should use unique keychain groups derived from its bundle identifier
+	var keychainIsolation: Bool
 
 	// MARK: Experiments
 	
@@ -146,6 +148,7 @@ struct Options: Codable, Equatable {
 		removeProvisioning: false,
 		changeLanguageFilesForCustomDisplayName: false,
 		injectIntoExtensions: false,
+		keychainIsolation: false,
 		
 		// MARK: Experiments
 		

--- a/Feather/Utilities/Handlers/SigningHandler.swift
+++ b/Feather/Utilities/Handlers/SigningHandler.swift
@@ -102,7 +102,9 @@ final class SigningHandler: NSObject {
 		
 		// iOS "26" (19) needs special treatment
 		try await _locateMachosAndFixupArm64eSlice(for: movedAppPath)
-		
+
+		try await _modifyEntitlementsForKeychainIsolation(for: movedAppPath)
+
 		let handler = ZsignHandler(appUrl: movedAppPath, options: _options, cert: appCertificate)
 		try await handler.disinject()
 		
@@ -179,6 +181,71 @@ final class SigningHandler: NSObject {
 }
 
 extension SigningHandler {
+	/// Replaces wildcard keychain-access-groups in entitlements with the app's
+	/// bundle identifier so each signed app gets its own keychain namespace.
+	private func _modifyEntitlementsForKeychainIsolation(for app: URL) async throws {
+		guard _options.keychainIsolation, let cert = appCertificate else {
+			return
+		}
+
+		// Determine the bundle identifier the signed app will use
+		let bundleId: String
+		if let customId = _options.appIdentifier {
+			bundleId = customId
+		} else {
+			guard
+				let infoPlist = NSDictionary(contentsOf: app.appendingPathComponent("Info.plist")),
+				let id = infoPlist["CFBundleIdentifier"] as? String
+			else {
+				return
+			}
+			bundleId = id
+		}
+
+		guard !bundleId.isEmpty else { return }
+
+		// Read entitlements: prefer user-supplied file, fall back to provisioning profile
+		let entitlementsDict: NSMutableDictionary
+
+		if let customFile = _options.appEntitlementsFile {
+			guard let dict = NSMutableDictionary(contentsOf: customFile) else { return }
+			entitlementsDict = dict
+		} else {
+			guard
+				let decoded = Storage.shared.getProvisionFileDecoded(for: cert),
+				let entitlements = decoded.Entitlements
+			else {
+				return
+			}
+			entitlementsDict = NSMutableDictionary(dictionary: entitlements.mapValues { $0.value })
+		}
+
+		// Replace wildcards in keychain-access-groups (e.g. "TEAMID.*" → "TEAMID.com.example.app")
+		// and filter out entries without a valid team ID prefix (e.g. com.apple.token)
+		guard var groups = entitlementsDict["keychain-access-groups"] as? [String] else { return }
+
+		let teamIdPattern = try NSRegularExpression(pattern: "^[A-Z0-9]{10}\\.")
+		groups = groups.compactMap { group in
+			let replaced = group.replacingOccurrences(of: "*", with: bundleId)
+			let range = NSRange(replaced.startIndex..., in: replaced)
+			guard teamIdPattern.firstMatch(in: replaced, range: range) != nil else { return nil }
+			return replaced
+		}
+
+		entitlementsDict["keychain-access-groups"] = groups
+
+		// Write modified entitlements to a temp file for zsign to use
+		let entitlementsURL = _uniqueWorkDir.appendingPathComponent("entitlements.plist")
+		let plistData = try PropertyListSerialization.data(
+			fromPropertyList: entitlementsDict,
+			format: .xml,
+			options: 0
+		)
+		try plistData.write(to: entitlementsURL)
+
+		_options.appEntitlementsFile = entitlementsURL
+	}
+
 	private func _modifyDict(using infoDictionary: NSMutableDictionary, with options: Options, to app: URL) async throws {
 		if options.fileSharing { infoDictionary.setObject(true, forKey: "UISupportsDocumentBrowser" as NSCopying) }
 		if options.itunesFileSharing { infoDictionary.setObject(true, forKey: "UIFileSharingEnabled" as NSCopying) }

--- a/Feather/Views/Signing/Shared/SigningOptionsView.swift
+++ b/Feather/Views/Signing/Shared/SigningOptionsView.swift
@@ -27,6 +27,17 @@ struct SigningOptionsView: View {
 				Text(.localized("Enabling any protection will append a random string to the bundleidentifiers of the apps you sign, this is to ensure your Apple ID does not get flagged by Apple. However, when using a signing service you can ignore this."))
 			}
 		}
+
+		NBSection(.localized("Security")) {
+			_toggle(
+				.localized("Keychain Isolation"),
+				systemImage: "key",
+				isOn: $options.keychainIsolation,
+				temporaryValue: temporaryOptions?.keychainIsolation
+			)
+		} footer: {
+			Text(.localized("Replaces wildcard keychain groups with the app's bundle identifier, preventing sideloaded apps from accessing each other's keychain entries."))
+		}
 		
 		NBSection(.localized("General")) {
 			Self.picker(


### PR DESCRIPTION
Fix https://github.com/CLARATION/Feather/issues/575

Currently all apps sideloaded with a given `.mobileprovision` use the same keychain group. This is a major security risk because any sideloaded app can snoop on other apps keychain entries (instagram tokens, telegram tokens, passwords for some apps, etc.).

This means that any malicious app can defeat iOS keychain sandboxing entirely instead of only being able to access its own keychain entries. This also causes conflicts when multiple apps use the same names for keychain entries, e.g. for cloned apps.

This pull request adds a new option for keychain isolation, inspired by Impactor.

The keychain group name is deterministically derived from the bundle id of the app to make sure that installing new versions of said app won’t lose the keychain entries.

I tested on several apps and I confirm that it works properly. It also works on apps making heavy use of extensions/widgets with different bundle IDs (e.g. CARROT) and I confirm that it works: the keychain group is shared among them rather than having a unique group for each extension.

Before (105 items from a bunch of unrelated apps):

<img height="700" alt="image" src="https://github.com/user-attachments/assets/364e815c-ee32-4f45-97f5-abcbe0f9ce8e" />

After (only the 2 items of the app):

<img height="700" alt="image" src="https://github.com/user-attachments/assets/345708f3-fca6-4c4b-b510-1c4b2765cf3b" />
