### PR TITLE
Track apps actually installed to the device

### DIFF
--- a/Feather/Backend/Storage/Feather.xcdatamodeld/Feather.xcdatamodel/contents
+++ b/Feather/Backend/Storage/Feather.xcdatamodeld/Feather.xcdatamodel/contents
@@ -31,6 +31,7 @@
         <attribute name="ppQCheck" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="revoked" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="uuid" attributeType="String"/>
+        <relationship name="installedApps" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="InstalledApp" inverseName="certificate" inverseEntity="InstalledApp"/>
         <relationship name="signedApps" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Signed" inverseName="certificate" inverseEntity="Signed"/>
     </entity>
     <entity name="Imported" representedClassName="Imported" syncable="YES" codeGenerationType="class">
@@ -41,6 +42,23 @@
         <attribute name="source" optional="YES" attributeType="URI"/>
         <attribute name="uuid" attributeType="String"/>
         <attribute name="version" attributeType="String"/>
+    </entity>
+    <entity name="InstalledApp" representedClassName="InstalledApp" syncable="YES" codeGenerationType="class">
+        <attribute name="certificateAppIDName" optional="YES" attributeType="String"/>
+        <attribute name="certificateExpiration" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="certificateName" optional="YES" attributeType="String"/>
+        <attribute name="certificateNickname" optional="YES" attributeType="String"/>
+        <attribute name="certificateRevoked" attributeType="Boolean" usesScalarValueType="YES" defaultValueString="NO"/>
+        <attribute name="certificateTeamIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="iconData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <attribute name="identifier" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="sourceRepositoryName" optional="YES" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <attribute name="version" attributeType="String"/>
+        <attribute name="wasSigned" attributeType="Boolean" usesScalarValueType="YES" defaultValueString="NO"/>
+        <relationship name="certificate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CertificatePair" inverseName="installedApps" inverseEntity="CertificatePair"/>
     </entity>
     <entity name="Signed" representedClassName="Signed" syncable="YES" codeGenerationType="class">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>

--- a/Feather/Backend/Storage/Storage+Certificate.swift
+++ b/Feather/Backend/Storage/Storage+Certificate.swift
@@ -32,6 +32,7 @@ extension Storage {
 		new.isDefault = isDefault
 		Storage.shared.revokagedCertificate(for: new)
 		saveContext()
+		relinkInstalledApps(toNewlyAddedCertificate: new)
 		generator.impactOccurred()
 		completion(nil)
 	}

--- a/Feather/Backend/Storage/Storage+InstalledApps.swift
+++ b/Feather/Backend/Storage/Storage+InstalledApps.swift
@@ -1,0 +1,116 @@
+//
+//  Storage+InstalledApps.swift
+//  Feather
+//
+
+import CoreData
+import Foundation
+import NimbleExtensions
+
+// Independent record of any app that completed a successful installation.
+// Holds a live reference to the certificate it was signed with + snapshots
+// the certificate's details.
+extension Storage {
+	func recordSuccessfulInstall(of app: AppInfoPresentable) {
+		guard let uuid = app.uuid, let identifier = app.identifier else { return }
+
+		let request: NSFetchRequest<InstalledApp> = InstalledApp.fetchRequest()
+		request.predicate = NSPredicate(format: "identifier == %@", identifier)
+		request.fetchLimit = 1
+
+		let installed = (try? context.fetch(request))?.first ?? InstalledApp(context: context)
+
+		installed.uuid = uuid
+		installed.identifier = identifier
+		installed.name = app.name ?? .localized("Unknown")
+		installed.version = app.version ?? ""
+		installed.wasSigned = app.isSigned
+		installed.date = Date()
+
+		_applyCertificateSnapshot(getCertificate(from: app), to: installed)
+
+		installed.sourceRepositoryName = sourceMetadata(for: app)?.sourceRepositoryName
+
+		if
+			let bundleURL = getAppDirectory(for: app),
+			let icon = iconTest(bundleURL)
+		{
+			installed.iconData = icon.pngData()
+		}
+
+		saveContext()
+	}
+
+	func getInstalledApps() -> [InstalledApp] {
+		let request: NSFetchRequest<InstalledApp> = InstalledApp.fetchRequest()
+		request.sortDescriptors = [NSSortDescriptor(keyPath: \InstalledApp.date, ascending: false)]
+		return (try? context.fetch(request)) ?? []
+	}
+
+	func deleteInstalledApp(_ app: InstalledApp) {
+		context.delete(app)
+		saveContext()
+	}
+
+	// called after a certificate is (re-)added, in case it's the same certificate
+	func relinkInstalledApps(toNewlyAddedCertificate certificate: CertificatePair) {
+		guard
+			let teamIdentifier = getProvisionFileDecoded(for: certificate)?.TeamIdentifier.first,
+			!teamIdentifier.isEmpty
+		else { return }
+
+		let request: NSFetchRequest<InstalledApp> = InstalledApp.fetchRequest()
+		request.predicate = NSPredicate(
+			format: "certificate == nil AND certificateTeamIdentifier == %@",
+			teamIdentifier
+		)
+
+		guard let orphaned = try? context.fetch(request), !orphaned.isEmpty else { return }
+
+		for installed in orphaned {
+			_applyCertificateSnapshot(certificate, to: installed)
+		}
+
+		saveContext()
+	}
+
+	private func _applyCertificateSnapshot(_ certificate: CertificatePair?, to installed: InstalledApp) {
+		installed.certificate = certificate
+
+		guard let certificate else {
+			installed.certificateNickname = nil
+			installed.certificateName = nil
+			installed.certificateAppIDName = nil
+			installed.certificateTeamIdentifier = nil
+			installed.certificateExpiration = nil
+			installed.certificateRevoked = false
+			return
+		}
+
+		let decoded = getProvisionFileDecoded(for: certificate)
+		installed.certificateNickname = certificate.nickname
+		installed.certificateName = decoded?.Name
+		installed.certificateAppIDName = decoded?.AppIDName
+		installed.certificateTeamIdentifier = decoded?.TeamIdentifier.first
+		installed.certificateExpiration = certificate.expiration
+		installed.certificateRevoked = certificate.revoked
+	}
+}
+
+extension InstalledApp: AppInfoPresentable {
+	var isSigned: Bool { wasSigned }
+	var source: URL? { nil }
+	var icon: String? { nil }
+}
+
+extension InstalledApp {
+	var certificateExpirationInfo: Date.ExpirationInfo? {
+		certificateExpiration?.expirationInfo()
+	}
+
+	var isCertificateExpiredOrRevoked: Bool {
+		if certificateRevoked { return true }
+		guard let expiration = certificateExpiration else { return false }
+		return expiration <= Date()
+	}
+}

--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    " • " : {
+
+    },
     "%lld Apps" : {
       "comment" : "Repository app count",
       "extractionState" : "manual",
@@ -3808,6 +3811,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加日期"
+          }
+        }
+      }
+    },
+    "Date Installed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date Installed"
           }
         }
       }
@@ -8989,6 +9003,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "安装类型"
+          }
+        }
+      }
+    },
+    "Installed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installed"
           }
         }
       }

--- a/Feather/Views/Library/Install/InstallPreviewView.swift
+++ b/Feather/Views/Library/Install/InstallPreviewView.swift
@@ -19,6 +19,7 @@ struct InstallPreviewView: View {
 	@AppStorage("Feather.serverMethod") private var _serverMethod: Int = 0
 	@State private var _isWebviewPresenting = false
 	@State private var progressTask: Task<Void, Never>?
+	@State private var _hasRecordedInstall = false
 	
 	var app: AppInfoPresentable
 	@StateObject var viewModel: InstallerStatusViewModel
@@ -57,6 +58,11 @@ struct InstallPreviewView: View {
 			SafariRepresentableView(url: installer.pageEndpoint).ignoresSafeArea()
 		}
 		.onReceive(viewModel.$status) { newStatus in
+			if case .completed(.success) = newStatus, !_hasRecordedInstall {
+				_hasRecordedInstall = true
+				Storage.shared.recordSuccessfulInstall(of: app)
+			}
+
 			if _installationMethod == 0 {
 				if case .ready = newStatus {
 					if _serverMethod == 0 {

--- a/Feather/Views/Library/InstalledAppCellView.swift
+++ b/Feather/Views/Library/InstalledAppCellView.swift
@@ -1,0 +1,171 @@
+//
+//  InstalledAppCellView.swift
+//  Feather
+//
+
+import SwiftUI
+import NimbleExtensions
+import NimbleViews
+
+// MARK: - View
+// Reflects Feather's own record of a successful install.
+struct InstalledAppCellView: View {
+	var app: InstalledApp
+
+	var body: some View {
+		// when the certificate still exists, observe it directly so a revocation flip
+		// (or any other change) redraws this row immediately, same as the Certificates list does
+		if let cert = app.certificate {
+			_ReactiveContent(app: app, cert: cert)
+		} else {
+			_StaticContent(app: app)
+		}
+	}
+}
+
+private struct _ReactiveContent: View {
+	var app: InstalledApp
+	@ObservedObject var cert: CertificatePair
+
+	var body: some View {
+		_InstalledAppRow(
+			app: app,
+			certNickname: cert.nickname,
+			certName: app.certificateName,
+			certExpiration: cert.expiration,
+			certRevoked: cert.revoked
+		)
+	}
+}
+
+private struct _StaticContent: View {
+	var app: InstalledApp
+
+	var body: some View {
+		_InstalledAppRow(
+			app: app,
+			certNickname: app.certificateNickname,
+			certName: app.certificateName,
+			certExpiration: app.certificateExpiration,
+			certRevoked: app.certificateRevoked
+		)
+	}
+}
+
+private struct _InstalledAppRow: View {
+	@Environment(\.horizontalSizeClass) private var horizontalSizeClass
+	@State private var _isInfoPresenting = false
+
+	var app: InstalledApp
+	var certNickname: String?
+	var certName: String?
+	var certExpiration: Date?
+	var certRevoked: Bool
+
+	private var _expirationInfo: Date.ExpirationInfo? {
+		certExpiration?.expirationInfo()
+	}
+
+	private var _isExpiredOrRevoked: Bool {
+		if certRevoked { return true }
+		guard let certExpiration else { return false }
+		return certExpiration <= Date()
+	}
+
+	private var _baseDesc: String {
+		var parts = ["\(app.version ?? "") • \(app.identifier ?? "")"]
+
+		if let displayName = certNickname ?? certName, !displayName.isEmpty {
+			parts.append(displayName)
+		}
+		if let repositoryName = app.sourceRepositoryName, !repositoryName.isEmpty {
+			parts.append(repositoryName)
+		}
+
+		return parts.joined(separator: " • ")
+	}
+
+	private var _subtitle: Text {
+		let base = Text(_baseDesc).foregroundColor(.secondary)
+		guard let expirationInfo = _expirationInfo else { return base }
+		let expirationText = _isExpiredOrRevoked ? .localized("Expired") : expirationInfo.formatted
+		return base
+			+ Text(" • ").foregroundColor(.secondary)
+			+ Text(expirationText).foregroundColor(_isExpiredOrRevoked ? .red : .blue)
+	}
+
+	private var _pillText: String {
+		if _isExpiredOrRevoked { return .localized("Expired") }
+		return _expirationInfo?.formatted ?? .localized("Open")
+	}
+
+	private var _pillColor: Color {
+		_isExpiredOrRevoked ? .red : .blue
+	}
+
+	var body: some View {
+		let isRegular = horizontalSizeClass != .compact
+
+		HStack(spacing: 18) {
+			_icon()
+
+			VStack(alignment: .leading, spacing: 2) {
+				Text(app.name ?? .localized("Unknown"))
+					.font(.headline)
+					.foregroundColor(.primary)
+				_subtitle
+					.font(.subheadline)
+			}
+			.lineLimit(0)
+			.frame(maxWidth: .infinity, alignment: .leading)
+
+			Button {
+				UIApplication.openApp(with: app.identifier ?? "")
+			} label: {
+				Text(_pillText)
+					.lineLimit(0)
+					.font(.headline.bold())
+					.foregroundStyle(.white)
+					.padding(.horizontal, 12)
+					.padding(.vertical, 6)
+					.background(_pillColor)
+					.clipShape(Capsule())
+			}
+			.buttonStyle(.borderless)
+		}
+		.padding(isRegular ? 12 : 0)
+		.background(
+			isRegular
+				? RoundedRectangle(cornerRadius: 18, style: .continuous)
+					.fill(Color(.quaternarySystemFill))
+				: nil
+		)
+		.contentShape(Rectangle())
+		.swipeActions {
+			Button(.localized("Delete"), systemImage: "trash", role: .destructive) {
+				Storage.shared.deleteInstalledApp(app)
+			}
+		}
+		.contextMenu {
+			Button(.localized("Get Info"), systemImage: "info.circle") {
+				_isInfoPresenting = true
+			}
+			Divider()
+			Button(.localized("Delete"), systemImage: "trash", role: .destructive) {
+				Storage.shared.deleteInstalledApp(app)
+			}
+		}
+		.sheet(isPresented: $_isInfoPresenting) {
+			InstalledAppInfoView(app: app)
+		}
+	}
+
+	@ViewBuilder
+	private func _icon() -> some View {
+		if let iconData = app.iconData, let uiImage = UIImage(data: iconData) {
+			Image(uiImage: uiImage).appIconStyle(size: 57)
+		} else {
+			FRAppIconView(app: app, size: 57)
+		}
+	}
+}

--- a/Feather/Views/Library/InstalledAppInfoView.swift
+++ b/Feather/Views/Library/InstalledAppInfoView.swift
@@ -1,0 +1,83 @@
+//
+//  InstalledAppInfoView.swift
+//  Feather
+//
+
+import SwiftUI
+import NimbleExtensions
+import NimbleViews
+
+// MARK: - View
+// Deliberately reads only the InstalledApp record so it still works after
+// the Signed/Imported entry that produced it has been deleted.
+struct InstalledAppInfoView: View {
+	var app: InstalledApp
+
+	// MARK: Body
+	var body: some View {
+		NBNavigationView(app.name ?? .localized("Unknown"), displayMode: .inline) {
+			List {
+				Section {} header: {
+					_icon()
+						.frame(maxWidth: .infinity, alignment: .center)
+				}
+
+				NBSection(.localized("Info")) {
+					if let name = app.name {
+						_infoCell(.localized("Name"), desc: name)
+					}
+					if let version = app.version {
+						_infoCell(.localized("Version"), desc: version)
+					}
+					if let identifier = app.identifier {
+						_infoCell(.localized("Identifier"), desc: identifier)
+					}
+					if let date = app.date {
+						_infoCell(.localized("Date Installed"), desc: date.formatted())
+					}
+				}
+
+				if let cert = app.certificate {
+					// live certificate still exists: show the exact same cell Signed's info view does
+					NBSection(.localized("Certificate")) {
+						CertificatesCellView(cert: cert)
+					}
+				} else if app.certificateNickname != nil || app.certificateName != nil || app.certificateAppIDName != nil {
+					// certificate has been deleted: fall back to what we snapshotted
+					NBSection(.localized("Certificate")) {
+						NBTitleWithSubtitleView(
+							title: app.certificateNickname ?? app.certificateName ?? .localized("Unknown"),
+							subtitle: app.certificateAppIDName ?? .localized("Unknown")
+						)
+						if let expirationInfo = app.certificateExpirationInfo {
+							LabeledContent(.localized("Expires")) {
+								Text(app.isCertificateExpiredOrRevoked ? .localized("Expired") : expirationInfo.formatted)
+									.foregroundStyle(app.isCertificateExpiredOrRevoked ? .red : .blue)
+							}
+						}
+					}
+				}
+			}
+			.toolbar {
+				NBToolbarButton(role: .close)
+			}
+		}
+	}
+
+	@ViewBuilder
+	private func _icon() -> some View {
+		if let iconData = app.iconData, let uiImage = UIImage(data: iconData) {
+			Image(uiImage: uiImage).appIconStyle()
+		} else {
+			FRAppIconView(app: app)
+		}
+	}
+
+	@ViewBuilder
+	private func _infoCell(_ title: String, desc: String) -> some View {
+		LabeledContent(title) {
+			Text(desc)
+		}
+		.copyableText(desc)
+	}
+}

--- a/Feather/Views/Library/LibraryView.swift
+++ b/Feather/Views/Library/LibraryView.swift
@@ -48,19 +48,29 @@ struct LibraryView: View {
 	private var _filteredImportedApps: [Imported] {
 		filteredAndSortedApps(from: _importedApps)
 	}
-	
+
+	private var _filteredInstalledApps: [InstalledApp] {
+		filteredAndSortedApps(from: _installedApps)
+	}
+
 	// MARK: Fetch
 	@FetchRequest(
 		entity: Signed.entity(),
 		sortDescriptors: [NSSortDescriptor(keyPath: \Signed.date, ascending: false)],
 		animation: .snappy
 	) private var _signedApps: FetchedResults<Signed>
-	
+
 	@FetchRequest(
 		entity: Imported.entity(),
 		sortDescriptors: [NSSortDescriptor(keyPath: \Imported.date, ascending: false)],
 		animation: .snappy
 	) private var _importedApps: FetchedResults<Imported>
+
+	@FetchRequest(
+		entity: InstalledApp.entity(),
+		sortDescriptors: [NSSortDescriptor(keyPath: \InstalledApp.date, ascending: false)],
+		animation: .snappy
+	) private var _installedApps: FetchedResults<InstalledApp>
 	
 	@FetchRequest(
 		entity: AltSource.entity(),
@@ -72,6 +82,20 @@ struct LibraryView: View {
 	var body: some View {
 		NBNavigationView(.localized("Library")) {
 			NBListAdaptable {
+				if
+					!_filteredInstalledApps.isEmpty,
+					_selectedScope == .all
+				{
+					NBSection(
+						.localized("Installed"),
+						secondary: _filteredInstalledApps.count.description
+					) {
+						ForEach(_filteredInstalledApps, id: \.uuid) { app in
+							InstalledAppCellView(app: app)
+						}
+					}
+				}
+
 				if
 					!_filteredSignedApps.isEmpty,
 					_selectedScope == .all || _selectedScope == .signed


### PR DESCRIPTION
## Summary
- Adds a new `InstalledApp` Core Data entity — an independent record of "this app was actually pushed to a device," kept separate from `Signed`/`Imported` so it survives deletion of the library entry that produced it.
- `InstallPreviewView` records a successful install exactly once, on the `.completed(.success)` status transition (covers both the server/AltStore-style install path and the iDevice pairing install path).
- New "Installed" section in the Library view (shown under the "All" scope), with a cell and a "Get Info" detail sheet that falls back to a snapshot of the certificate's details (nickname, AppID name, team identifier, expiration, revoked) once the live certificate is deleted.
- When a certificate is re-added, orphaned `InstalledApp` rows are relinked to it by matching team identifier.

## Test plan
- [x] Project builds cleanly (`xcodebuild ... build` → `BUILD SUCCEEDED`)
- [ ] Manually verify on-device: install an app, confirm it shows under the new "Installed" section, confirm "Get Info" and delete work
- [ ] Manually verify: delete the certificate used to sign an installed app, confirm the row still shows via the snapshot; re-add the same certificate, confirm it relinks