### PR TITLE
feat: Add Feather self certificate match

### DIFF
--- a/Feather/Resources/Localizable.xcstrings
+++ b/Feather/Resources/Localizable.xcstrings
@@ -6003,6 +6003,26 @@
         }
       }
     },
+    "Feather app was signed using this certificate." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feather app was signed using this certificate."
+          }
+        }
+      }
+    },
+    "Feather must be updated with a new certificate once this one expires." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feather must be updated with a new certificate once this one expires."
+          }
+        }
+      }
+    },
     "Featured" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Feather/Utilities/CertificateReader/Models/CertificateModel.swift
+++ b/Feather/Utilities/CertificateReader/Models/CertificateModel.swift
@@ -48,3 +48,22 @@ struct Certificate: Codable {
 		case derEncodedProfile = "DER-Encoded-Profile"
 	}
 }
+
+// MARK: - Extension: Feather signing certificate
+extension Certificate {
+	/// Feather's own embedded provisioning profile decoded once and cached for the app's lifetime.
+	static let feather: Certificate? = {
+		let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision")
+		return CertificateReader(url).decoded
+	}()
+
+	/// Checks a given certificate is the same one by byte comparison used to sign Feather app,
+	var signedFeather: Bool {
+		guard
+			let featherCerts = Certificate.feather?.DeveloperCertificates,
+			let certs = DeveloperCertificates
+		else { return false }
+
+		return certs.contains(where: featherCerts.contains)
+	}
+}

--- a/Feather/Views/Settings/Certificates/CertificatesCellView.swift
+++ b/Feather/Views/Settings/Certificates/CertificatesCellView.swift
@@ -37,6 +37,11 @@ struct CertificatesCellView: View {
 		.frame(height: 80)
 		.contentTransition(.opacity)
 		.frame(maxWidth: .infinity, alignment: .leading)
+		.overlay(alignment: .topTrailing) {
+			if data?.signedFeather == true {
+				FRAppIconView(size: 20)
+			}
+		}
 		.onAppear {
 			withAnimation {
 				data = Storage.shared.getProvisionFileDecoded(for: cert)

--- a/Feather/Views/Settings/Certificates/Info/CertificatesInfoView.swift
+++ b/Feather/Views/Settings/Certificates/Info/CertificatesInfoView.swift
@@ -27,7 +27,19 @@ struct CertificatesInfoView: View {
 						.frame(width: 107, height: 107)
 						.frame(maxWidth: .infinity, alignment: .center)
 				}
-				
+
+				if data?.signedFeather == true {
+					Section {
+						Label {
+							Text(.localized("Feather app was signed using this certificate."))
+						} icon: {
+							FRAppIconView(size: 24)
+						}
+					} footer: {
+						Text(.localized("Feather must be updated with a new certificate once this one expires."))
+					}
+				}
+
 				if let data {
 					_infoSection(data: data)
 					_entitlementsSection(data: data)


### PR DESCRIPTION
Providing a way to identify the actual certificate that signed the Feather app itself. In many cases app's default cert should be the self certificate but not always. This change helps identify the certificate that is signed for Feather itself.

Tested with local certificate by signing & manually adding the certificate.

<img width="300" height="650" alt="IMG_1194" src="https://github.com/user-attachments/assets/f42f535c-2566-4253-afaf-194a0153b3c0" />
